### PR TITLE
doc fix for read_structure_at

### DIFF
--- a/src/fs_tree.rs
+++ b/src/fs_tree.rs
@@ -150,7 +150,7 @@ impl FsTree {
     ///
     /// This function will make at maximum `self.len()` syscalls.
     ///
-    /// If you don't want symlink-awareness, check [`FsTree::symlink_read_structure_at`].
+    /// If you want symlink-awareness, check [`FsTree::symlink_read_structure_at`].
     ///
     /// # Examples:
     ///


### PR DESCRIPTION
I noticed a small error in the documentation for `read_structure_at` and so here's a tiny PR to fix it.